### PR TITLE
Only log when state changes

### DIFF
--- a/lib/logUpdate.js
+++ b/lib/logUpdate.js
@@ -1,0 +1,12 @@
+const keys = Object.create(null)
+
+module.exports = (log) => ({
+  ...log,
+  update: (key, value) => {
+    if (keys[key] === value) return
+
+    keys[key] = value
+
+    return log.info(key, value)
+  }
+})

--- a/lib/logUpdate.js
+++ b/lib/logUpdate.js
@@ -3,10 +3,10 @@ const keys = Object.create(null)
 module.exports = (log) => ({
   ...log,
   update: (key, value) => {
-    if (keys[key] === value) return
+    const update = (keys[key] !== value)
 
-    keys[key] = value
+    if(update) keys[key] = value
 
-    return log.info(key, value)
+    return log[update ? 'info' : 'debug'](key, value)
   }
 })


### PR DESCRIPTION
This PR changes the logging so that it only output state, when the state has actually changed since the last time it was output. I have also changed the main code to use `log.error` for error messages.

I think this is a better way of addressing #14, as now only useful messages get logged, rather than have an all or nothing approach.